### PR TITLE
feat: redesign team experience

### DIFF
--- a/frontend/src/pages/TeamDetail.jsx
+++ b/frontend/src/pages/TeamDetail.jsx
@@ -1,76 +1,725 @@
-import { useEffect, useState } from 'react';
-import { Card, Empty, List, Skeleton, Statistic, Tag, Typography } from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Empty,
+  List,
+  Row,
+  Select,
+  Skeleton,
+  Statistic,
+  Table,
+  Tag,
+  Typography,
+} from 'antd';
+import { ArrowLeftOutlined, LineChartOutlined, TeamOutlined } from '@ant-design/icons';
 import { useNavigate, useParams } from 'react-router-dom';
 import { fetchTeam } from '../utils/api.js';
 
-const { Title } = Typography;
+const { Title, Paragraph } = Typography;
+
+const TEAM_STORAGE_KEY = 'fbref-custom-teams';
+
+const formationOptions = ['4-3-3', '4-2-3-1', '4-4-2', '3-5-2', '3-4-3', '5-3-2', '4-1-4-1'];
+
+const STARTER_KEYS = ['is_starter', 'isStarter', 'is_starting', 'starting', 'starter', 'start', 'in_starting_xi'];
+
+const STAT_PATHS = {
+  minutes: [
+    ['minutes'],
+    ['stats', 'minutes'],
+    ['statistics', 'minutes'],
+    ['summary', 'minutes'],
+    ['minutes_played'],
+    ['games', 'minutes'],
+    ['details', 'minutes_played'],
+  ],
+  goals: [['goals'], ['stats', 'goals'], ['statistics', 'goals'], ['summary', 'goals'], ['details', 'goals']],
+  assists: [['assists'], ['stats', 'assists'], ['statistics', 'assists'], ['summary', 'assists'], ['details', 'assists']],
+  xg: [
+    ['xg'],
+    ['stats', 'xg'],
+    ['advanced', 'xg'],
+    ['expected_goals'],
+    ['metrics', 'xg'],
+    ['details', 'xg'],
+  ],
+  xa: [
+    ['xa'],
+    ['stats', 'xa'],
+    ['advanced', 'xa'],
+    ['expected_assists'],
+    ['metrics', 'xa'],
+    ['details', 'xa'],
+  ],
+  matches: [
+    ['matches'],
+    ['stats', 'matches'],
+    ['statistics', 'matches'],
+    ['summary', 'matches'],
+    ['appearances'],
+    ['games', 'appearances'],
+  ],
+  shots: [
+    ['shots'],
+    ['stats', 'shots'],
+    ['statistics', 'shots'],
+    ['summary', 'shots'],
+    ['details', 'shots'],
+  ],
+};
+
+const readLocalTeams = () => {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(TEAM_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('Yerel takım verisi okunamadı', error);
+    return [];
+  }
+};
+
+const getNestedValue = (obj, path) => {
+  return path.reduce((acc, key) => {
+    if (acc !== null && acc !== undefined && Object.prototype.hasOwnProperty.call(acc, key)) {
+      return acc[key];
+    }
+    return undefined;
+  }, obj);
+};
+
+const pickValue = (obj, paths) => {
+  for (const path of paths) {
+    const value = getNestedValue(obj, path);
+    if (value !== undefined && value !== null && value !== '') {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const toNumber = (value) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+};
+
+const formatNumber = (value, digits = 1) => {
+  if (value === null || value === undefined) {
+    return '-';
+  }
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    return '-';
+  }
+  return num.toFixed(digits);
+};
+
+const parseFormation = (formation) => {
+  if (!formation) {
+    return [4, 3, 3];
+  }
+  const tokens = String(formation)
+    .split(/[^0-9]/)
+    .map((part) => Number(part))
+    .filter((part) => Number.isFinite(part) && part > 0);
+  return tokens.length ? tokens : [4, 3, 3];
+};
+
+const parseNumericLike = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.replace(',', '.');
+    const asNumber = Number(normalized);
+    if (Number.isFinite(asNumber)) {
+      return asNumber;
+    }
+    const asFloat = parseFloat(normalized);
+    if (Number.isFinite(asFloat)) {
+      return asFloat;
+    }
+  }
+  return null;
+};
+
+const getPlayerIdentifier = (player) => {
+  return (
+    player?.id ??
+    player?.player_id ??
+    player?.slug ??
+    player?.uuid ??
+    (player?.name ? `${player.name}-${player.position || ''}` : undefined)
+  );
+};
+
+const isStarter = (player) => {
+  if (!player) {
+    return false;
+  }
+  if (player.role && player.role !== 'bench') {
+    return true;
+  }
+  if (player.is_local && player.is_starter) {
+    return true;
+  }
+  return STARTER_KEYS.some((key) => {
+    const value = player[key];
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const normalized = value.toLowerCase();
+      return ['true', 'starter', 'starting', 'yes', 'xi'].includes(normalized);
+    }
+    return false;
+  });
+};
+
+const computeFirstEleven = (players = []) => {
+  if (!players.length) {
+    return [];
+  }
+  const starters = players.filter(isStarter);
+  const seen = new Set();
+  const firstEleven = [];
+  const minutesSorted = [...players].sort((a, b) => {
+    const minutesB = toNumber(pickValue(b, STAT_PATHS.minutes));
+    const minutesA = toNumber(pickValue(a, STAT_PATHS.minutes));
+    return minutesB - minutesA;
+  });
+
+  const pushPlayer = (player) => {
+    const identifier = getPlayerIdentifier(player);
+    if (!identifier || seen.has(identifier)) {
+      return;
+    }
+    seen.add(identifier);
+    firstEleven.push(player);
+  };
+
+  starters.forEach(pushPlayer);
+  minutesSorted.forEach((player) => {
+    if (firstEleven.length < 11) {
+      pushPlayer(player);
+    }
+  });
+  players.forEach((player) => {
+    if (firstEleven.length < 11) {
+      pushPlayer(player);
+    }
+  });
+
+  return firstEleven.slice(0, 11);
+};
+
+const buildPitchLayout = (players = [], formation) => {
+  if (!players.length) {
+    return [];
+  }
+  const formationNumbers = parseFormation(formation);
+
+  const goalkeeper = players.find((player) => {
+    const position = String(player?.position || '').toUpperCase();
+    return position.includes('GK') || position.includes('KAL');
+  }) || players[0];
+
+  const goalkeeperId = getPlayerIdentifier(goalkeeper);
+  const outfieldPlayers = players.filter((player) => getPlayerIdentifier(player) !== goalkeeperId);
+
+  const lines = [];
+  let cursor = 0;
+  formationNumbers.forEach((count) => {
+    const slice = outfieldPlayers.slice(cursor, cursor + count);
+    lines.push(slice);
+    cursor += count;
+  });
+  if (cursor < outfieldPlayers.length && lines.length) {
+    lines[lines.length - 1] = [...lines[lines.length - 1], ...outfieldPlayers.slice(cursor)];
+  }
+
+  const reversed = [...lines].reverse();
+  const verticalStart = 12;
+  const verticalEnd = 72;
+  const verticalStep = reversed.length > 1 ? (verticalEnd - verticalStart) / (reversed.length - 1) : 0;
+
+  const layout = [];
+  reversed.forEach((linePlayers, rowIndex) => {
+    if (!linePlayers.length) {
+      return;
+    }
+    const top = verticalStart + rowIndex * verticalStep;
+    const gap = 100 / (linePlayers.length + 1);
+    linePlayers.forEach((player, index) => {
+      layout.push({
+        player,
+        style: {
+          top: `${top}%`,
+          left: `${gap * (index + 1)}%`,
+        },
+      });
+    });
+  });
+
+  layout.push({
+    player: goalkeeper,
+    style: {
+      top: '84%',
+      left: '50%',
+    },
+  });
+
+  return layout;
+};
+
+const inferFormationFromPlayers = (players = []) => {
+  if (!players.length) {
+    return '4-3-3';
+  }
+  const firstEleven = computeFirstEleven(players);
+  const defence = ['CB', 'LB', 'RB', 'LCB', 'RCB', 'DEF', 'LWB', 'RWB'];
+  const midfield = ['DM', 'CDM', 'CM', 'LCM', 'RCM', 'AM', 'CAM', 'LM', 'RM', 'MID'];
+  let defenders = 0;
+  let midfielders = 0;
+  let forwards = 0;
+
+  firstEleven.forEach((player) => {
+    const position = String(player?.position || '').toUpperCase();
+    if (position.includes('GK')) {
+      return;
+    }
+    if (defence.some((tag) => position.includes(tag))) {
+      defenders += 1;
+    } else if (midfield.some((tag) => position.includes(tag))) {
+      midfielders += 1;
+    } else {
+      forwards += 1;
+    }
+  });
+
+  const totalOutfield = defenders + midfielders + forwards;
+  if (totalOutfield < 10) {
+    const missing = 10 - totalOutfield;
+    forwards += missing;
+  }
+
+  return `${Math.max(defenders, 3)}-${Math.max(midfielders, 2)}-${Math.max(forwards, 1)}`;
+};
 
 function TeamDetailPage() {
   const { teamId } = useParams();
   const navigate = useNavigate();
   const [team, setTeam] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [selectedFormation, setSelectedFormation] = useState('4-3-3');
+  const [error, setError] = useState(null);
 
   useEffect(() => {
+    let ignore = false;
+    const isLocalTeam = String(teamId).startsWith('local-');
+
     const loadTeam = async () => {
       try {
         setLoading(true);
-        const data = await fetchTeam(teamId);
-        setTeam(data);
-      } catch (error) {
-        console.error('Takım bilgisi alınamadı', error);
+        setError(null);
+        if (isLocalTeam) {
+          const localTeam = readLocalTeams().find((item) => String(item.id) === String(teamId));
+          setTeam(localTeam || null);
+          if (!localTeam) {
+            setError('Takım bilgisi bulunamadı');
+          }
+        } else {
+          const data = await fetchTeam(teamId);
+          if (!ignore) {
+            setTeam(data);
+          }
+        }
+      } catch (err) {
+        console.error('Takım bilgisi alınamadı', err);
+        const localTeam = readLocalTeams().find((item) => String(item.id) === String(teamId));
+        if (localTeam) {
+          setTeam(localTeam);
+        } else {
+          setError('Takım verisi yüklenemedi');
+          setTeam(null);
+        }
       } finally {
-        setLoading(false);
+        if (!ignore) {
+          setLoading(false);
+        }
       }
     };
 
     loadTeam();
+
+    return () => {
+      ignore = true;
+    };
   }, [teamId]);
 
+  useEffect(() => {
+    if (!team) {
+      return;
+    }
+    const derivedFormation =
+      team.preferred_formation || team.formation || inferFormationFromPlayers(team.players);
+    setSelectedFormation(derivedFormation);
+  }, [team?.id]);
+
+  const players = team?.players || [];
+  const firstEleven = useMemo(() => computeFirstEleven(players), [players]);
+
+  const benchPlayers = useMemo(() => {
+    const firstElevenIds = new Set(firstEleven.map((player) => getPlayerIdentifier(player)));
+    return players.filter((player) => !firstElevenIds.has(getPlayerIdentifier(player)));
+  }, [players, firstEleven]);
+
+  const pitchLayout = useMemo(
+    () => buildPitchLayout(firstEleven, selectedFormation),
+    [firstEleven, selectedFormation],
+  );
+
+  const metrics = team?.metrics || {};
+  const metricsPossessionNumber = parseNumericLike(metrics.possession);
+  const metricsPossessionValue =
+    metricsPossessionNumber !== null ? Number(metricsPossessionNumber.toFixed(1)) : metrics.possession;
+
+  const aggregatedStats = useMemo(() => {
+    if (!players.length) {
+      return { goals: 0, assists: 0, xg: 0, xa: 0, minutes: 0, matches: 0, avgAge: null };
+    }
+    const totals = players.reduce(
+      (acc, player) => {
+        acc.goals += toNumber(pickValue(player, STAT_PATHS.goals));
+        acc.assists += toNumber(pickValue(player, STAT_PATHS.assists));
+        acc.xg += toNumber(pickValue(player, STAT_PATHS.xg));
+        acc.xa += toNumber(pickValue(player, STAT_PATHS.xa));
+        acc.minutes += toNumber(pickValue(player, STAT_PATHS.minutes));
+        acc.matches += toNumber(pickValue(player, STAT_PATHS.matches));
+        const age = Number(player.age);
+        if (Number.isFinite(age)) {
+          acc.ages.push(age);
+        }
+        return acc;
+      },
+      { goals: 0, assists: 0, xg: 0, xa: 0, minutes: 0, matches: 0, ages: [] },
+    );
+
+    const avgAge = totals.ages.length
+      ? (totals.ages.reduce((sum, age) => sum + age, 0) / totals.ages.length).toFixed(1)
+      : null;
+
+    const { ages, ...rest } = totals;
+    return { ...rest, avgAge };
+  }, [players]);
+
+  const columns = useMemo(
+    () => [
+      {
+        title: 'Oyuncu',
+        dataIndex: 'name',
+        key: 'name',
+        fixed: 'left',
+        render: (value, record) => (
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ fontWeight: 600 }}>{value}</span>
+            <span style={{ fontSize: 12, color: '#8c8c8c' }}>{record.position}</span>
+          </div>
+        ),
+      },
+      {
+        title: 'Rol',
+        dataIndex: 'role',
+        key: 'role',
+        render: (role) => (
+          <Tag color={role === 'İlk 11' ? 'green' : 'blue'}>{role}</Tag>
+        ),
+      },
+      {
+        title: 'Forma',
+        dataIndex: 'number',
+        key: 'number',
+        align: 'center',
+      },
+      {
+        title: 'Maç',
+        dataIndex: 'matches',
+        key: 'matches',
+        align: 'center',
+      },
+      {
+        title: 'Dakika',
+        dataIndex: 'minutes',
+        key: 'minutes',
+        align: 'center',
+      },
+      {
+        title: 'Gol',
+        dataIndex: 'goals',
+        key: 'goals',
+        align: 'center',
+      },
+      {
+        title: 'Asist',
+        dataIndex: 'assists',
+        key: 'assists',
+        align: 'center',
+      },
+      {
+        title: 'Şut',
+        dataIndex: 'shots',
+        key: 'shots',
+        align: 'center',
+      },
+      {
+        title: 'xG',
+        dataIndex: 'xg',
+        key: 'xg',
+        align: 'center',
+      },
+      {
+        title: 'xA',
+        dataIndex: 'xa',
+        key: 'xa',
+        align: 'center',
+      },
+    ],
+    [],
+  );
+
+  const playerRows = useMemo(() => {
+    const firstElevenIds = new Set(firstEleven.map((player) => getPlayerIdentifier(player)));
+    return players.map((player) => {
+      const identifier = getPlayerIdentifier(player) || player.name;
+      const role = firstElevenIds.has(identifier) ? 'İlk 11' : 'Yedek';
+      const minutes = pickValue(player, STAT_PATHS.minutes);
+      const matches = pickValue(player, STAT_PATHS.matches);
+      const goals = pickValue(player, STAT_PATHS.goals);
+      const assists = pickValue(player, STAT_PATHS.assists);
+      const xg = pickValue(player, STAT_PATHS.xg);
+      const xa = pickValue(player, STAT_PATHS.xa);
+      const shots = pickValue(player, STAT_PATHS.shots);
+
+      return {
+        key: identifier,
+        name: player.name,
+        position: player.position || '-',
+        role,
+        number: player.number ?? player.shirtNumber ?? '-',
+        matches: matches ?? '-',
+        minutes: minutes ?? '-',
+        goals: goals ?? '-',
+        assists: assists ?? '-',
+        xg: typeof xg === 'number' ? xg.toFixed(2) : xg ?? '-',
+        xa: typeof xa === 'number' ? xa.toFixed(2) : xa ?? '-',
+        shots: shots ?? '-',
+      };
+    });
+  }, [players, firstEleven]);
+
   if (loading) {
-    return <Skeleton active paragraph={{ rows: 6 }} />;
+    return <Skeleton active paragraph={{ rows: 8 }} />;
   }
 
   if (!team) {
-    return <Empty description="Takım bulunamadı" />;
+    return <Empty description={error || 'Takım bulunamadı'} />;
   }
 
   return (
-    <div>
-      <Title level={3} className="page-header">
-        {team.name}
-      </Title>
-      <Card style={{ marginBottom: 24 }}>
-        <div style={{ display: 'flex', gap: 32, flexWrap: 'wrap' }}>
-          <Statistic title="Lig" value={team.league || 'Bilinmiyor'} />
-          <Statistic title="Ülke" value={team.country || 'Bilinmiyor'} />
-          <Statistic title="Oyuncu Sayısı" value={team.players.length} />
-        </div>
-      </Card>
-
-      <Card title="Kadrodaki Oyuncular">
-        {team.players.length ? (
-          <List
-            itemLayout="horizontal"
-            dataSource={team.players}
-            renderItem={(player) => (
-              <List.Item onClick={() => navigate(`/players/${player.id}`)} style={{ cursor: 'pointer' }}>
-                <List.Item.Meta
-                  title={player.name}
-                  description={
-                    <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
-                      {player.position && <Tag color="geekblue">{player.position}</Tag>}
-                      <span>Yaş: {player.age || '-'}</span>
-                      {player.nationality && <span>Ülke: {player.nationality}</span>}
-                    </div>
-                  }
-                />
-              </List.Item>
-            )}
-          />
-        ) : (
-          <Empty description="Oyuncu bulunamadı" />
+    <div className="team-detail-page">
+      <Button type="text" icon={<ArrowLeftOutlined />} onClick={() => navigate(-1)} style={{ marginBottom: 16 }}>
+        Geri Dön
+      </Button>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
+        <Title level={3} style={{ margin: 0 }}>
+          {team.name}
+        </Title>
+        <Tag color="blue">{team.league || 'Lig Bilgisi Yok'}</Tag>
+        {team.country && <Tag color="geekblue">{team.country}</Tag>}
+        {String(team.id).startsWith('local-') && (
+          <Tag color="green" icon={<TeamOutlined />}>Özel Kadro</Tag>
         )}
+      </div>
+      {team.description && (
+        <Paragraph type="secondary" style={{ marginTop: 8, maxWidth: 680 }}>
+          {team.description}
+        </Paragraph>
+      )}
+      {error && (
+        <Alert style={{ marginTop: 16 }} message={error} type="warning" showIcon />
+      )}
+
+      <Row gutter={[24, 24]} style={{ marginTop: 24 }}>
+        <Col xs={24} xl={16}>
+          <Card
+            title="Diziliş ve İlk 11"
+            extra={
+              <Select
+                value={selectedFormation}
+                onChange={setSelectedFormation}
+                options={[...new Set([selectedFormation, team.preferred_formation, team.formation, ...formationOptions])]
+                  .filter(Boolean)
+                  .map((value) => ({ label: value, value }))}
+                style={{ minWidth: 140 }}
+              />
+            }
+          >
+            {pitchLayout.length ? (
+              <div className="team-pitch-wrapper">
+                <div className="team-pitch">
+                  <div className="pitch-half pitch-half--top" />
+                  <div className="pitch-half pitch-half--bottom" />
+                  <div className="pitch-center-circle" />
+                  <div className="pitch-center-line" />
+                  <div className="pitch-penalty pitch-penalty--top" />
+                  <div className="pitch-penalty pitch-penalty--bottom" />
+                  {pitchLayout.map(({ player, style }) => {
+                    const identifier = getPlayerIdentifier(player) || player.name;
+                    const goals = pickValue(player, STAT_PATHS.goals);
+                    const xg = pickValue(player, STAT_PATHS.xg);
+                    const assists = pickValue(player, STAT_PATHS.assists);
+                    return (
+                      <div key={identifier} className="pitch-player" style={style}>
+                        <div className="pitch-player__number">{player.number ?? player.shirtNumber ?? '-'}</div>
+                        <div className="pitch-player__name">{player.name}</div>
+                        <div className="pitch-player__meta">
+                          <span>{player.position || ''}</span>
+                          {goals !== undefined && goals !== null && goals !== '' && (
+                            <span>G:{goals}</span>
+                          )}
+                          {xg !== undefined && xg !== null && xg !== '' && (
+                            <span>xG:{formatNumber(xg, 2)}</span>
+                          )}
+                          {assists !== undefined && assists !== null && assists !== '' && (
+                            <span>A:{assists}</span>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="pitch-legend">
+                  <Tag icon={<LineChartOutlined />} color="processing">
+                    Oyuncu kartlarında gol, asist ve xG değerleri görüntülenir
+                  </Tag>
+                </div>
+              </div>
+            ) : (
+              <Empty description="İlk 11 bilgisi bulunamadı" />
+            )}
+          </Card>
+        </Col>
+        <Col xs={24} xl={8}>
+          <Card title="Takım Özeti">
+            <Row gutter={[16, 16]}>
+              <Col span={12}>
+                <Statistic title="Toplam Gol" value={aggregatedStats.goals || 0} />
+              </Col>
+              <Col span={12}>
+                <Statistic title="Toplam Asist" value={aggregatedStats.assists || 0} />
+              </Col>
+              <Col span={12}>
+                <Statistic title="Toplam xG" value={formatNumber(aggregatedStats.xg, 2)} />
+              </Col>
+              <Col span={12}>
+                <Statistic title="Toplam xA" value={formatNumber(aggregatedStats.xa, 2)} />
+              </Col>
+              <Col span={12}>
+                <Statistic title="Toplam Dakika" value={aggregatedStats.minutes || 0} />
+              </Col>
+              <Col span={12}>
+                <Statistic title="Maç" value={aggregatedStats.matches || players.length || 0} />
+              </Col>
+            </Row>
+            {aggregatedStats.avgAge && (
+              <div style={{ marginTop: 16 }}>
+                <Statistic title="Ortalama Yaş" value={aggregatedStats.avgAge} />
+              </div>
+            )}
+            {team.metrics && (
+              <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
+                {team.metrics.goals !== undefined && team.metrics.goals !== null && (
+                  <Col span={12}>
+                    <Statistic title="Sezon Golleri" value={team.metrics.goals} />
+                  </Col>
+                )}
+                {team.metrics.xg !== undefined && team.metrics.xg !== null && (
+                  <Col span={12}>
+                    <Statistic title="Sezon xG" value={formatNumber(team.metrics.xg, 2)} />
+                  </Col>
+                )}
+                {team.metrics.xa !== undefined && team.metrics.xa !== null && (
+                  <Col span={12}>
+                    <Statistic title="Sezon xA" value={formatNumber(team.metrics.xa, 2)} />
+                  </Col>
+                )}
+                {team.metrics.possession !== undefined && team.metrics.possession !== null && (
+                  <Col span={12}>
+                    <Statistic
+                      title="Topla Oynama"
+                      value={
+                        metricsPossessionNumber !== null ? metricsPossessionValue : team.metrics.possession
+                      }
+                      suffix={metricsPossessionNumber !== null ? '%' : undefined}
+                    />
+                  </Col>
+                )}
+              </Row>
+            )}
+          </Card>
+
+          {benchPlayers.length > 0 && (
+            <Card title="Yedek Kulübesi" style={{ marginTop: 24 }}>
+              <List
+                dataSource={benchPlayers}
+                renderItem={(player) => {
+                  const xg = pickValue(player, STAT_PATHS.xg);
+                  const assists = pickValue(player, STAT_PATHS.assists);
+                  return (
+                    <List.Item>
+                      <List.Item.Meta
+                        title={player.name}
+                        description={
+                          <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', fontSize: 12 }}>
+                            <span>Mevki: {player.position || '-'}</span>
+                            {player.number && <span>Forma: {player.number}</span>}
+                            {xg !== undefined && xg !== null && xg !== '' && (
+                              <span>xG: {formatNumber(xg, 2)}</span>
+                            )}
+                            {assists !== undefined && assists !== null && assists !== '' && (
+                              <span>Asist: {assists}</span>
+                            )}
+                          </div>
+                        }
+                      />
+                    </List.Item>
+                  );
+                }}
+              />
+            </Card>
+          )}
+        </Col>
+      </Row>
+
+      <Card title="Oyuncu İstatistikleri" style={{ marginTop: 24 }}>
+        <Table
+          columns={columns}
+          dataSource={playerRows}
+          pagination={{ pageSize: 15, showSizeChanger: false }}
+          scroll={{ x: true }}
+        />
       </Card>
     </div>
   );

--- a/frontend/src/pages/Teams.jsx
+++ b/frontend/src/pages/Teams.jsx
@@ -1,23 +1,129 @@
-import { useEffect, useState } from 'react';
-import { Card, Col, Input, Row, Statistic, Typography } from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Card,
+  Col,
+  Form,
+  Input,
+  InputNumber,
+  Modal,
+  Popconfirm,
+  Row,
+  Select,
+  Space,
+  Statistic,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import { DeleteOutlined, MinusCircleOutlined, PlusOutlined, TeamOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import { fetchTeams } from '../utils/api.js';
 
-const { Title } = Typography;
+const { Title, Paragraph } = Typography;
+
+const TEAM_STORAGE_KEY = 'fbref-custom-teams';
+
+const FORMATION_OPTIONS = [
+  '4-3-3',
+  '4-2-3-1',
+  '4-4-2',
+  '3-5-2',
+  '3-4-3',
+  '5-3-2',
+  '4-1-4-1',
+  '4-3-1-2',
+  '4-5-1',
+].map((value) => ({ label: value, value }));
+
+const POSITION_OPTIONS = [
+  'GK',
+  'RB',
+  'RWB',
+  'CB',
+  'LB',
+  'LWB',
+  'DM',
+  'CM',
+  'AM',
+  'RM',
+  'LM',
+  'RW',
+  'LW',
+  'CF',
+  'ST',
+].map((value) => ({ label: value, value }));
+
+const ROLE_OPTIONS = [
+  { label: 'İlk 11', value: 'starter' },
+  { label: 'Yedek', value: 'bench' },
+];
+
+const safeReadLocalTeams = () => {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(TEAM_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('Yerel takımlar okunamadı', error);
+    return [];
+  }
+};
+
+const persistLocalTeams = (teams) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(TEAM_STORAGE_KEY, JSON.stringify(teams));
+  } catch (error) {
+    console.warn('Yerel takımlar kaydedilemedi', error);
+  }
+};
+
+const filterTeams = (teams, searchValue) => {
+  if (!searchValue) {
+    return teams;
+  }
+  const term = searchValue.toLowerCase();
+  return teams.filter((team) =>
+    [team.name, team.league, team.country]
+      .filter(Boolean)
+      .some((field) => field.toLowerCase().includes(term)),
+  );
+};
 
 function TeamsPage() {
   const navigate = useNavigate();
+  const [form] = Form.useForm();
   const [teams, setTeams] = useState([]);
+  const [localTeams, setLocalTeams] = useState([]);
+  const [searchValue, setSearchValue] = useState('');
   const [filteredTeams, setFilteredTeams] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setLocalTeams(safeReadLocalTeams());
+  }, []);
 
   useEffect(() => {
     const loadTeams = async () => {
       try {
         setLoading(true);
         const data = await fetchTeams();
-        setTeams(data.teams);
-        setFilteredTeams(data.teams);
+        const apiTeams = Array.isArray(data?.teams) ? data.teams : [];
+        setTeams(apiTeams);
       } catch (error) {
         console.error('Takımlar yüklenemedi', error);
       } finally {
@@ -28,46 +134,350 @@ function TeamsPage() {
     loadTeams();
   }, []);
 
-  const handleSearch = (value) => {
-    if (!value) {
-      setFilteredTeams(teams);
-      return;
-    }
+  const mergedTeams = useMemo(() => {
+    return [...teams, ...localTeams];
+  }, [teams, localTeams]);
 
-    const term = value.toLowerCase();
-    setFilteredTeams(
-      teams.filter((team) => team.name.toLowerCase().includes(term) || (team.league || '').toLowerCase().includes(term)),
-    );
+  useEffect(() => {
+    setFilteredTeams(filterTeams(mergedTeams, searchValue));
+  }, [mergedTeams, searchValue]);
+
+  const handleSearch = (value) => {
+    setSearchValue(value);
+  };
+
+  const handleAddTeam = async () => {
+    try {
+      setSubmitting(true);
+      const values = await form.validateFields();
+      const now = Date.now();
+      const teamId = `local-${now}`;
+      const players = (values.players || []).map((player, index) => ({
+        ...player,
+        id: `local-${now}-${index}`,
+        is_local: true,
+        is_starter: player.role !== 'bench',
+        stats: {
+          goals: Number(player.goals ?? 0) || 0,
+          assists: Number(player.assists ?? 0) || 0,
+          minutes: Number(player.minutes ?? 0) || 0,
+          xg: Number(player.xg ?? 0) || 0,
+          xa: Number(player.xa ?? 0) || 0,
+        },
+      }));
+
+      const newTeam = {
+        id: teamId,
+        name: values.name,
+        league: values.league,
+        country: values.country,
+        description: values.description,
+        preferred_formation: values.formation,
+        formation: values.formation,
+        metrics: {
+          goals: Number(values.teamGoals ?? 0) || 0,
+          xg: Number(values.teamXg ?? 0) || 0,
+          xa: Number(values.teamXa ?? 0) || 0,
+          possession: Number(values.teamPossession ?? 0) || 0,
+        },
+        players,
+        player_count: players.length,
+        created_at: new Date().toISOString(),
+        isCustom: true,
+      };
+
+      const updatedLocalTeams = [...localTeams, newTeam];
+      setLocalTeams(updatedLocalTeams);
+      persistLocalTeams(updatedLocalTeams);
+      message.success('Takım başarıyla eklendi');
+      setModalVisible(false);
+      form.resetFields();
+    } catch (error) {
+      console.error('Takım ekleme başarısız', error);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDeleteTeam = (teamId) => {
+    const updatedLocalTeams = localTeams.filter((team) => team.id !== teamId);
+    setLocalTeams(updatedLocalTeams);
+    persistLocalTeams(updatedLocalTeams);
+    message.success('Takım kaldırıldı');
   };
 
   return (
     <div>
-      <Title level={3} className="page-header">
-        Takım Analizi
-      </Title>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
+        <div>
+          <Title level={3} className="page-header" style={{ marginBottom: 8 }}>
+            Takım Analizi
+          </Title>
+          <Paragraph type="secondary" style={{ marginBottom: 0 }}>
+            Takımları keşfedin, özel kadrolar oluşturun ve dizilişleri yeşil sahada görselleştirin.
+          </Paragraph>
+        </div>
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalVisible(true)}>
+          Yeni Takım Ekle
+        </Button>
+      </div>
       <Input.Search
         placeholder="Takım ara"
         allowClear
         onSearch={handleSearch}
-        style={{ maxWidth: 320, marginBottom: 24 }}
+        onChange={(event) => handleSearch(event.target.value)}
+        style={{ maxWidth: 340, marginBottom: 24 }}
         loading={loading}
+        value={searchValue}
       />
       <Row gutter={[16, 16]}>
-        {filteredTeams.map((team) => (
-          <Col key={team.id} xs={24} md={12} lg={8} xl={6}>
-            <Card
-              hoverable
-              onClick={() => navigate(`/teams/${team.id}`)}
-              style={{ borderRadius: 12 }}
-              title={team.name}
-            >
-              <Statistic title="Lig" value={team.league || 'Bilinmiyor'} />
-              <Statistic title="Ülke" value={team.country || 'Bilinmiyor'} style={{ marginTop: 12 }} />
-              <Statistic title="Oyuncu Sayısı" value={team.player_count} style={{ marginTop: 12 }} />
-            </Card>
-          </Col>
-        ))}
+        {filteredTeams.map((team) => {
+          const isCustom = String(team.id).startsWith('local-') || team.isCustom;
+          const playerCount = team.player_count || team.players?.length || 0;
+          return (
+            <Col key={team.id} xs={24} md={12} lg={8} xl={6}>
+              <Card
+                hoverable
+                onClick={() => navigate(`/teams/${team.id}`)}
+                style={{ borderRadius: 14, height: '100%' }}
+                title={
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span>{team.name}</span>
+                    {isCustom && (
+                      <Tag color="green" icon={<TeamOutlined />}
+                        style={{ borderRadius: 12, padding: '0 8px', fontSize: 12 }}
+                      >
+                        Özel Kadro
+                      </Tag>
+                    )}
+                  </div>
+                }
+                extra={
+                  isCustom ? (
+                    <Popconfirm
+                      title="Bu özel takımı kaldırmak istediğinize emin misiniz?"
+                      okText="Evet"
+                      cancelText="Vazgeç"
+                      onConfirm={() => handleDeleteTeam(team.id)}
+                    >
+                      <Button
+                        type="text"
+                        icon={<DeleteOutlined />}
+                        danger
+                        onClick={(event) => event.stopPropagation()}
+                      />
+                    </Popconfirm>
+                  ) : null
+                }
+              >
+                <Statistic title="Lig" value={team.league || 'Bilinmiyor'} />
+                <Statistic title="Ülke" value={team.country || 'Bilinmiyor'} style={{ marginTop: 12 }} />
+                <Statistic
+                  title="Oyuncu Sayısı"
+                  value={playerCount}
+                  style={{ marginTop: 12 }}
+                />
+                <Statistic
+                  title="Tercih edilen Diziliş"
+                  value={team.preferred_formation || team.formation || '4-3-3'}
+                  style={{ marginTop: 12 }}
+                />
+              </Card>
+            </Col>
+          );
+        })}
       </Row>
+
+      <Modal
+        title="Yeni Takım Oluştur"
+        open={modalVisible}
+        onCancel={() => setModalVisible(false)}
+        onOk={handleAddTeam}
+        okText="Takımı Kaydet"
+        confirmLoading={submitting}
+        width={900}
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical" initialValues={{ formation: '4-3-3', players: [] }}>
+          <Row gutter={16}>
+            <Col xs={24} md={12}>
+              <Form.Item name="name" label="Takım Adı" rules={[{ required: true, message: 'Takım adı gerekli' }]}>
+                <Input placeholder="Ör. Galaktik FC" allowClear />
+              </Form.Item>
+            </Col>
+            <Col xs={24} md={12}>
+              <Form.Item name="league" label="Lig" rules={[{ required: true, message: 'Lig bilgisi gerekli' }]}>
+                <Input placeholder="Ör. Süper Lig" allowClear />
+              </Form.Item>
+            </Col>
+            <Col xs={24} md={12}>
+              <Form.Item name="country" label="Ülke">
+                <Input placeholder="Ülke" allowClear />
+              </Form.Item>
+            </Col>
+            <Col xs={24} md={12}>
+              <Form.Item name="formation" label="Tercih Edilen Diziliş">
+                <Select options={FORMATION_OPTIONS} showSearch allowClear={false} />
+              </Form.Item>
+            </Col>
+          </Row>
+
+          <Form.Item name="description" label="Kısa Not">
+            <Input.TextArea rows={2} placeholder="Takım hakkında kısa notlar" allowClear />
+          </Form.Item>
+
+          <Row gutter={16}>
+            <Col xs={24} md={6}>
+              <Form.Item name="teamGoals" label="Toplam Gol">
+                <InputNumber min={0} precision={0} style={{ width: '100%' }} />
+              </Form.Item>
+            </Col>
+            <Col xs={24} md={6}>
+              <Form.Item name="teamXg" label="Toplam xG">
+                <InputNumber min={0} precision={2} step={0.1} style={{ width: '100%' }} />
+              </Form.Item>
+            </Col>
+            <Col xs={24} md={6}>
+              <Form.Item name="teamXa" label="Toplam xA">
+                <InputNumber min={0} precision={2} step={0.1} style={{ width: '100%' }} />
+              </Form.Item>
+            </Col>
+            <Col xs={24} md={6}>
+              <Form.Item name="teamPossession" label="Toplam Topla Oynama (%)">
+                <InputNumber min={0} max={100} precision={1} style={{ width: '100%' }} />
+              </Form.Item>
+            </Col>
+          </Row>
+
+          <Title level={4} style={{ marginTop: 24 }}>
+            Kadro ve Oyuncu İstatistikleri
+          </Title>
+          <Paragraph type="secondary" style={{ marginBottom: 12 }}>
+            En az 11 oyuncu ekleyerek ilk 11 dizilimini oluşturabilirsiniz. Yedek oyuncular da eklenebilir.
+          </Paragraph>
+
+          <Form.List
+            name="players"
+            rules={[
+              {
+                validator: async (_, value) => {
+                  if (!value || value.length < 11) {
+                    return Promise.reject(new Error('Kadronuz en az 11 oyuncudan oluşmalıdır.'));
+                  }
+                  return Promise.resolve();
+                },
+              },
+            ]}
+          >
+            {(fields, { add, remove }, { errors }) => (
+              <>
+                {fields.map((field, index) => (
+                  <Space
+                    key={field.key}
+                    style={{ display: 'flex', marginBottom: 8 }}
+                    align="baseline"
+                    wrap
+                  >
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'name']}
+                      fieldKey={[field.fieldKey, 'name']}
+                      label={index === 0 ? 'Oyuncu Adı' : ''}
+                      rules={[{ required: true, message: 'Oyuncu adı gerekli' }]}
+                    >
+                      <Input placeholder="Oyuncu adı" allowClear />
+                    </Form.Item>
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'position']}
+                      fieldKey={[field.fieldKey, 'position']}
+                      label={index === 0 ? 'Mevki' : ''}
+                      rules={[{ required: true, message: 'Mevki gerekli' }]}
+                    >
+                      <Select
+                        options={POSITION_OPTIONS}
+                        placeholder="Mevki"
+                        style={{ minWidth: 110 }}
+                      />
+                    </Form.Item>
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'role']}
+                      fieldKey={[field.fieldKey, 'role']}
+                      label={index === 0 ? 'Rol' : ''}
+                      initialValue="starter"
+                    >
+                      <Select options={ROLE_OPTIONS} style={{ minWidth: 120 }} />
+                    </Form.Item>
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'number']}
+                      fieldKey={[field.fieldKey, 'number']}
+                      label={index === 0 ? 'Forma No' : ''}
+                    >
+                      <InputNumber min={0} max={99} style={{ width: 90 }} />
+                    </Form.Item>
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'minutes']}
+                      fieldKey={[field.fieldKey, 'minutes']}
+                      label={index === 0 ? 'Dakika' : ''}
+                    >
+                      <InputNumber min={0} style={{ width: 110 }} />
+                    </Form.Item>
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'goals']}
+                      fieldKey={[field.fieldKey, 'goals']}
+                      label={index === 0 ? 'Gol' : ''}
+                    >
+                      <InputNumber min={0} style={{ width: 90 }} />
+                    </Form.Item>
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'assists']}
+                      fieldKey={[field.fieldKey, 'assists']}
+                      label={index === 0 ? 'Asist' : ''}
+                    >
+                      <InputNumber min={0} style={{ width: 90 }} />
+                    </Form.Item>
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'xg']}
+                      fieldKey={[field.fieldKey, 'xg']}
+                      label={index === 0 ? 'xG' : ''}
+                    >
+                      <InputNumber min={0} step={0.1} style={{ width: 90 }} />
+                    </Form.Item>
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'xa']}
+                      fieldKey={[field.fieldKey, 'xa']}
+                      label={index === 0 ? 'xA' : ''}
+                    >
+                      <InputNumber min={0} step={0.1} style={{ width: 90 }} />
+                    </Form.Item>
+                    {fields.length > 1 ? (
+                      <MinusCircleOutlined onClick={() => remove(field.name)} />
+                    ) : null}
+                  </Space>
+                ))}
+                <Form.Item>
+                  <Button
+                    type="dashed"
+                    onClick={() => add({ role: 'starter' })}
+                    block
+                    icon={<PlusOutlined />}
+                  >
+                    Oyuncu Ekle
+                  </Button>
+                  <Form.ErrorList errors={errors} />
+                </Form.Item>
+              </>
+            )}
+          </Form.List>
+        </Form>
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -49,3 +49,140 @@ body {
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 16px;
 }
+
+.team-detail-page .ant-card {
+  border-radius: 16px;
+}
+
+.team-pitch-wrapper {
+  background: linear-gradient(135deg, #0b8f3a, #0a6b32);
+  border-radius: 20px;
+  padding: 18px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 12px 32px rgba(8, 96, 40, 0.25);
+}
+
+.team-pitch {
+  position: relative;
+  width: 100%;
+  padding-top: 140%;
+  border: 2px solid rgba(255, 255, 255, 0.45);
+  border-radius: 18px;
+  background: linear-gradient(0deg, rgba(11, 117, 45, 0.95) 0%, rgba(17, 143, 60, 0.95) 100%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.pitch-half {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 50%;
+}
+
+.pitch-half--top {
+  top: 0;
+  border-bottom: 2px solid rgba(255, 255, 255, 0.35);
+}
+
+.pitch-half--bottom {
+  bottom: 0;
+  border-top: 2px solid rgba(255, 255, 255, 0.35);
+}
+
+.pitch-center-circle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 18%;
+  height: 18%;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.pitch-center-line {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.3);
+  transform: translateY(-50%);
+}
+
+.pitch-penalty {
+  position: absolute;
+  left: 50%;
+  width: 62%;
+  height: 22%;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-radius: 16px;
+  transform: translateX(-50%);
+}
+
+.pitch-penalty--top {
+  top: 4%;
+}
+
+.pitch-penalty--bottom {
+  bottom: 4%;
+}
+
+.pitch-player {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  color: #ffffff;
+  min-width: 92px;
+  max-width: 120px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow: 0 10px 24px rgba(5, 48, 22, 0.35);
+  backdrop-filter: blur(4px);
+}
+
+.pitch-player__number {
+  font-weight: 700;
+  font-size: 16px;
+  margin-bottom: 4px;
+}
+
+.pitch-player__name {
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+.pitch-player__meta {
+  margin-top: 6px;
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  opacity: 0.85;
+}
+
+.pitch-legend {
+  margin-top: 18px;
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .pitch-player {
+    min-width: 76px;
+    padding: 8px;
+    font-size: 12px;
+  }
+
+  .pitch-player__number {
+    font-size: 14px;
+  }
+
+  .team-pitch-wrapper {
+    padding: 14px;
+  }
+}


### PR DESCRIPTION
## Summary
- add local team management with formation-aware creation workflow on the teams page
- deliver a refreshed team detail view with tactical pitch, metrics, and bench insights
- style the pitch and team views for a greener, matchday-inspired presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4ee486a208328bf69c633d0b0d312