### PR TITLE
Add FastAPI team CRUD endpoints

### DIFF
--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -65,7 +65,27 @@ class TeamDetail(BaseModel):
     name: str
     league: Optional[str]
     country: Optional[str]
+    fbref_url: Optional[str]
     players: List[PlayerListItem]
+
+
+class TeamCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    league: Optional[str] = Field(default=None, max_length=100)
+    country: Optional[str] = Field(default=None, max_length=50)
+    fbref_url: Optional[str] = Field(default=None, max_length=500)
+
+
+class TeamUpdateRequest(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    league: Optional[str] = Field(default=None, max_length=100)
+    country: Optional[str] = Field(default=None, max_length=50)
+    fbref_url: Optional[str] = Field(default=None, max_length=500)
+
+
+class OperationResult(BaseModel):
+    success: bool
+    message: str
 
 
 class ScrapeRequest(BaseModel):


### PR DESCRIPTION
## Summary
- add create, update, and delete endpoints for teams with validation and player detachment
- extend team schemas to support creation payloads and fbref links
- return fbref URLs in detailed team responses for clients

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e4fbc58a748328962867f492ca9865